### PR TITLE
include sys/sysmacros.h for major/minor/makedev

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,7 @@ AX_C_BIGENDIAN_CROSS
 AC_FUNC_ALLOCA
 AC_CHECK_HEADERS([errno.h arpa/inet.h fcntl.h limits.h locale.h malloc.h stddef.h sys/file.h sys/mount.h sys/param.h sys/statvfs.h syslog.h wchar.h])
 AC_CHECK_HEADERS([execinfo.h ucontext.h sched.h])
+AC_CHECK_HEADERS([sys/sysmacros.h])
 AC_CHECK_HEADERS([sys/xattr.h])
 
 # Checks for typedefs, structures, and compiler characteristics.

--- a/rar2fs.c
+++ b/rar2fs.c
@@ -56,6 +56,9 @@
 #ifdef HAVE_SYS_XATTR_H
 # include <sys/xattr.h>
 #endif
+#ifdef HAVE_SYS_SYSMACROS_H
+# include <sys/sysmacros.h>
+#endif
 #ifdef HAVE_ICONV
 #include <iconv.h>
 #endif


### PR DESCRIPTION
These funcs are defined in sys/sysmacros.h, so include the header to
fix building with C libs that don't implicitly include via sys/types.h.

Signed-off-by: Mike Frysinger <vapier@gentoo.org>