### PR TITLE
Fix dump_buf writing to NULL and lookup_filecopy not using its cloned string.

### DIFF
--- a/rar2fs.c
+++ b/rar2fs.c
@@ -1243,9 +1243,9 @@ static void dump_buf(int seq, FILE *fp, char *buf, off_t offset, size_t size)
         size_t size_saved = size;
 
         memset(out, 0, 128);
-        fprintf(fp, "seq=%d offset: %" PRIu64 "   size: %zu   buf: %p", seq, offset, size, buf);
         size = size > 64 ? 64 : size;
         if (fp) {
+                fprintf(fp, "seq=%d offset: %" PRIu64 "   size: %zu   buf: %p", seq, offset, size, buf);
                 for (i = 0; i < size; i++) {
                         if (!i || !(i % 10)) {
                                 sprintf(tmp, "\n%016llx : ", offset + i);

--- a/rar2fs.c
+++ b/rar2fs.c
@@ -2065,7 +2065,7 @@ static dir_elem_t *lookup_filecopy(const char *path, RARArchiveListEx *next,
                                 ABS_MP(mp2, (*rar_root ? rar_root : "/"), tmp);
                         } else {
                                 char *rar_dir = strdup(tmp);
-                                ABS_MP(mp2, path, basename(tmp));
+                                ABS_MP(mp2, path, basename(rar_dir));
                                 free(rar_dir);
                         }
                         e_p = filecache_get(mp2);


### PR DESCRIPTION
I'd squash these commits tbh.
