### PR TITLE
Fix building with libc++.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,8 +33,8 @@ rar2fs_SOURCES = 	dllext.cpp \
 			dllext.hpp
 
 rar2fs_LDADD = $(PTHREAD_CFLAGS) $(LDFLAGS) $(UNRAR_LDFLAGS) $(FUSE_LDFLAGS) \
-		$(PTHREAD_LIBS) $(FUSE_LIBS) $(UNRAR_LIBS) $(LIBICONV) -lstdc++
-rar2fs_LINK = $(CC) -o $@
+		$(PTHREAD_LIBS) $(FUSE_LIBS) $(UNRAR_LIBS) $(LIBICONV)
+rar2fs_LINK = $(CXX) -o $@
 mkr2i_SOURCES = mkr2i.c
 mkr2i_LDADD = $(LDFLAGS)
 mkr2i_LINK = $(CC) -o $@


### PR DESCRIPTION
Do not hardcode stdc++ when linking. Rather, use C++
compiler as the linker driver which will choose correct
C++ library for linking.

Chrome OS bug:
https://bugs.chromium.org/p/chromium/issues/detail?id=1026266