### PR TITLE
Add .clang_format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: LLVM
+AlignEscapedNewlines: Left
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Linux
+BreakStringLiterals: false
+ColumnLimit: 80
+IndentCaseLabels: false
+IndentWidth: 8


### PR DESCRIPTION
This is a first version of .clang_format that fits nicely with the
existing code base. No code has been reformatted yet, but it might be
useful to have for future patches.