### PR TITLE
fix: correct ifdef check for VER_UNKNOWN

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ zimme              simon+github#AT#fridlund.email
 ivoronin           ivoronin#AT#gmail.com
 KyleSanderson
 vapier             vapier#AT#gmail.com
+fastcat            fastcat#AT#gmail.com

--- a/src/dllext.cpp
+++ b/src/dllext.cpp
@@ -510,7 +510,7 @@ static size_t ListFileHeader(wchar *wcs,Archive &Arc)
 
   wcs += msprintf(wcs, L"\n%12ls: RAR %ls(v%d) -m%d -md=%d%s",St(MListCompInfo),
           Format==RARFMT15 ? L"1.5":L"5.0",
-#if RARVER_MAJOR > 5 || ( RARVER_MAJOR == 5 && RARVER_MINOR > 60 )
+#if RARVER_MAJOR > 5 || ( RARVER_MAJOR == 5 && RARVER_MINOR >= 70 )
           hd.UnpVer==VER_UNKNOWN ? 0 : hd.UnpVer,hd.Method,
 #else
           hd.UnpVer,hd.Method,


### PR DESCRIPTION
Trying to build `rar2fs` for Debian, and thus using the version of the unrar source (and libraries) available there, I ran into a build error around `VER_UNKNOWN`.

That `#define` first showed up in 5.7.1, and is unavailable in 5.6.6, which reports `RARVER_MINOR = 61`