### PR TITLE
Fix parse error when filename contains ']'

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -51,4 +51,6 @@
 #define ABS_MP(s, path, file) ABS_MP_(s, path, file, alloca)
 #define ABS_MP2(s, path, file) ABS_MP_(s, path, file, malloc)
 
+#define str_beginwith(text, prefix) (!strncmp(text, prefix, strlen(prefix)))
+
 #endif

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -219,7 +219,7 @@ static int __hashtable_entry_delete_subkeys(void *h, const char *key,
         while (p->next) {
                 n = p;
                 p = p->next;
-                if ((hash == b->hash) && (strstr(p->key, key) == p->key)) {
+                if ((hash == b->hash) && str_beginwith(p->key, key)) {
                         level = __hashtable_entry_delete_subkeys(h, key,
                                                          get_hash(p->key, 0),
                                                          level);
@@ -230,7 +230,7 @@ static int __hashtable_entry_delete_subkeys(void *h, const char *key,
                 }
         }
         /* Finally check the bucket */
-        if (b->key && (hash == b->hash) && (strstr(b->key, key) == b->key)) {
+        if (b->key && (hash == b->hash) && str_beginwith(b->key, key)) {
                 level = __hashtable_entry_delete_subkeys(h, key,
                                                  get_hash(b->key, 0),
                                                  level);
@@ -267,13 +267,13 @@ void hashtable_entry_delete_subkeys(void *h, const char *key, uint32_t hash)
                 while (p->next) {
                         n = p;
                         p = p->next;
-                        if (strstr(p->key, key) == p->key) {
+                        if (str_beginwith(p->key, key)) {
                                 hashtable_entry_delete_hash(h, p->key, p->hash);
                                 p = n;
                         }
                 }
                 /* Finally check the bucket */
-                if (b->key && (strstr(b->key, key) == b->key))
+                if (b->key && str_beginwith(b->key, key))
                         hashtable_entry_delete_hash(h, b->key, b->hash);
         }
 }

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -243,7 +243,7 @@ static int get_save_eof(char *rar)
                 char *s = OPT_STR(OPT_KEY_SRC, 0);
                 int save_eof;
 
-                if (strstr(rar, s))
+                if (str_beginwith(rar, s))
                         rar += strlen(s);
                 save_eof = rarconfig_getprop(int, rar, RAR_SAVE_EOF_PROP);
                 if (save_eof >= 0)
@@ -270,7 +270,7 @@ static const char *get_alias(const char *rar, const char *file)
 
                 ABS_MP(file_abs, "/", file);
 
-                if (strstr(rar, s))
+                if (str_beginwith(rar, s))
                         rar += strlen(s);
                 alias = rarconfig_getalias(rar, file_abs);
                 if (alias)
@@ -294,7 +294,7 @@ static int get_seek_length(char *rar)
                 char *s = OPT_STR(OPT_KEY_SRC, 0);
                 int seek_len;
 
-                if (strstr(rar, s))
+                if (str_beginwith(rar, s))
                         rar += strlen(s);
                 seek_len = rarconfig_getprop(int, rar, RAR_SEEK_LENGTH_PROP);
                 if (seek_len >= 0)
@@ -481,8 +481,11 @@ static char *get_password(const char *file, char *buf, size_t len)
         tmp = rar;
         s = OPT_STR(OPT_KEY_SRC, 0);
 
-        if (strstr(rar, s))
+        int slen = strlen(s);
+        if (!strncmp(rar, s, slen)){
                 rar += strlen(s);
+        }
+
         password = rarconfig_getprop(prop_type_, rar,
                                 RAR_PASSWORD_PROP);
         if (password) {

--- a/src/rarconfig.c
+++ b/src/rarconfig.c
@@ -246,12 +246,20 @@ static struct parent_node *find_next_parent(FILE *fp, struct parent_node *p)
                 fseek(fp, 0L, SEEK_SET);
 
         while (fgets(line, LINE_MAX, fp)) {
-                if (sscanf(line, " [ %[^]] ", s) == 1) {
-                        p = malloc(sizeof(struct parent_node));
-                        p->name = strdup(s);
-                        p->pos = ftell(fp);
-                        return p;
-                }
+                const char *lstart=line;
+                while (isspace(*lstart)) lstart++;
+                if (*lstart!='[') continue;
+                lstart++;
+
+                const char *lend=lstart+strlen(lstart)-1;
+                while (lend>lstart && *lend!=']') lend--;
+                if (lend==lstart) continue;    // Shall we warn on invalid line here?
+                *(char*)lend = '\0';
+
+                p = malloc(sizeof(struct parent_node));
+                p->name = strdup(lstart);
+                p->pos = ftell(fp);
+                return p;
         }
 
         return NULL;


### PR DESCRIPTION
As title says.

BTW I also changed all `strstr` aiming for prefix matching to `strncmp`. I wonder if all these changed positions needs prefix matching, or precise matching? If the latter, could we just use `strcmp` instead?