### PR TITLE
Update configure.ac to support newer autotools

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -504,6 +504,8 @@ fi
 ########################################################
 
 AM_ICONV
+AM_GNU_GETTEXT([external])
+AM_GNU_GETTEXT_VERSION([0.14.4])
 
 AC_MSG_CHECKING(for commit hash in git repo)
 GITHEAD=$BUILDDIR/.git/$(cat $BUILDDIR/.git/HEAD 2>/dev/null | cut -d" " -f2)


### PR DESCRIPTION
Fixes:
- configure.ac:506: error: required file 'config/config.rpath' not found

explicitly require GETTEXT version
This is required by `autopoint` executed by `autoreconf`