### PR TITLE
Add passthrough support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = src man
+SUBDIRS = src man tests
 
 EXTRA_DIST = get-version.sh rarconfig.example

--- a/configure.ac
+++ b/configure.ac
@@ -202,6 +202,37 @@ if test x"$withval" != x; then
     fi
 fi
 
+AC_ARG_ENABLE([fuse3],
+   [AS_HELP_STRING([--disable-fuse3],
+               [do not prefer libfuse3 on Linux when it is available]
+   )],
+   [enable_fuse3=$enableval], [enable_fuse3=auto])
+
+use_fuse3=no
+case "$host_os" in
+linux*)
+    if test x"$enable_fuse3" != x"no"; then
+        AC_ARG_VAR([PKG_CONFIG], [path to pkg-config])
+        AC_PATH_TOOL([PKG_CONFIG], [pkg-config], [no])
+        if test x"$PKG_CONFIG" != x"no" &&
+           $PKG_CONFIG --exists 'fuse3 >= 3.17.1'; then
+            use_fuse3=yes
+            FUSE_CPPFLAGS="`$PKG_CONFIG --cflags fuse3` $FUSE_CPPFLAGS"
+            FUSE_LIBS="`$PKG_CONFIG --libs fuse3`"
+        elif test x"$enable_fuse3" = x"yes"; then
+            AC_MSG_ERROR([libfuse3 >= 3.17.1 was requested but was not found])
+        fi
+    fi
+    ;;
+*)
+    if test x"$enable_fuse3" = x"yes"; then
+        AC_MSG_ERROR([libfuse3 support is currently available on Linux only])
+    fi
+    ;;
+esac
+
+AM_CONDITIONAL([FUSE3], [test x"$use_fuse3" = x"yes"])
+
 static_unrar=fallback
 enableval=
 AC_ARG_ENABLE([static-unrar],
@@ -253,7 +284,11 @@ if test x"$withval" != x; then
     fi
 fi
 
-FUSE_CPPFLAGS="$FUSE_CPPFLAGS -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26"
+if test x"$use_fuse3" = x"yes"; then
+    FUSE_CPPFLAGS="$FUSE_CPPFLAGS -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=31"
+else
+    FUSE_CPPFLAGS="$FUSE_CPPFLAGS -D_FILE_OFFSET_BITS=64 -DFUSE_USE_VERSION=26"
+fi
 UNRAR_CXXFLAGS="-DRARDLL"
 AC_SUBST(FUSE_CPPFLAGS)
 AC_SUBST(UNRAR_CPPFLAGS)
@@ -304,21 +339,23 @@ save_LDFLAGS="$LDFLAGS"
 save_LIBS="$LIBS"
 LDFLAGS="$LDFLAGS $FUSE_LDFLAGS $PTHREAD_CFLAGS"
 LIBS="$PTHREAD_LIBS $LIBS"
-AC_CHECK_LIB(osxfuse_i64,fuse_new, [FUSE_LIBS="-losxfuse_i64"],
-    [ AC_CHECK_LIB(osxfuse,fuse_new, [FUSE_LIBS="-losxfuse"],
-        [ AC_CHECK_LIB(fuse_ino64,fuse_new, [FUSE_LIBS="-lfuse_ino64"],
-            [ AC_CHECK_LIB(fuse4x,fuse_new, [FUSE_LIBS="-lfuse4x"],
-                [ AC_CHECK_LIB(fuse,fuse_new, [FUSE_LIBS="-lfuse"],
-                    [ AC_CHECK_LIB(dokanfuse1.dll,fuse_new, [FUSE_LIBS="-ldokanfuse1.dll"],
-                        [AC_MSG_ERROR([
-                            Cannot find fuse library - add alternative library search path using
-                            --with-fuse-lib and rerun configure. ])
+if test x"$use_fuse3" != x"yes"; then
+    AC_CHECK_LIB(osxfuse_i64,fuse_new, [FUSE_LIBS="-losxfuse_i64"],
+        [ AC_CHECK_LIB(osxfuse,fuse_new, [FUSE_LIBS="-losxfuse"],
+            [ AC_CHECK_LIB(fuse_ino64,fuse_new, [FUSE_LIBS="-lfuse_ino64"],
+                [ AC_CHECK_LIB(fuse4x,fuse_new, [FUSE_LIBS="-lfuse4x"],
+                    [ AC_CHECK_LIB(fuse,fuse_new, [FUSE_LIBS="-lfuse"],
+                        [ AC_CHECK_LIB(dokanfuse1.dll,fuse_new, [FUSE_LIBS="-ldokanfuse1.dll"],
+                            [AC_MSG_ERROR([
+                                Cannot find fuse library - add alternative library search path using
+                                --with-fuse-lib and rerun configure. ])
+                        ],)
                     ],)
                 ],)
             ],)
         ],)
     ],)
-],)
+fi
 LIBS="$FUSE_LIBS $LIBS"
 # fuse_version() became available for the first time in fuse 2.7
 AC_CHECK_FUNCS(fuse_version)
@@ -334,7 +371,8 @@ if test x"$cross_compiling" = x"no"; then
         AC_LANG_PROGRAM([[
              #include <fuse.h>]],
     [[
-        if(FUSE_MAJOR_VERSION == 2 && FUSE_MINOR_VERSION >= 6)
+        if((FUSE_MAJOR_VERSION == 2 && FUSE_MINOR_VERSION >= 6) ||
+           FUSE_MAJOR_VERSION == 3)
             return 0;
         return -1;
     ]])],
@@ -751,6 +789,5 @@ CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
 AC_CONFIG_FILES([Makefile])
 AC_CONFIG_FILES([src/Makefile])
 AC_CONFIG_FILES([man/Makefile])
+AC_CONFIG_FILES([tests/Makefile])
 AC_OUTPUT
-
-

--- a/man/rar2fs.1
+++ b/man/rar2fs.1
@@ -232,6 +232,24 @@ specific locale to be applied in such character set conversions. The possible va
 easily be determined by the \fB`locale -a`\fR command.
 .RE
 .TP
+.B \-o passthrough=off|auto|force
+control kernel passthrough for normal local files
+.PP
+.RS
+On Linux systems built with libfuse3 passthrough support, local files that are
+not archive members can have their read and write operations redirected by the
+kernel directly to the backing file. The default mode is
+.BR auto ,
+which enables passthrough when both libfuse and the kernel support it and
+otherwise falls back to normal FUSE I/O.
+.B off
+always uses normal FUSE I/O.
+.B force
+fails the mount if passthrough cannot be negotiated and fails a local-file open
+if its backing file cannot be registered. Files inside RAR archives always use
+rar2fs extraction I/O and are never opened in passthrough mode.
+.RE
+.TP
 .B \-o warmup
 .TP
 .B \-o warmup=THREADS
@@ -264,4 +282,3 @@ Project home page
 .B Hans Beckerus
 .br
 .I \<hans.beckerus#AT#gmail.com\>
-

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -41,10 +41,14 @@
 # include <fuse_lowlevel.h>
 # if defined(__linux__) && defined(FUSE_CAP_PASSTHROUGH)
 #  include <sys/ioctl.h>
+#  include <sys/vfs.h>
 #  include <linux/fuse.h>
 #  if defined(FUSE_DEV_IOC_BACKING_OPEN) && \
                 defined(FUSE_DEV_IOC_BACKING_CLOSE)
 #   define HAVE_FUSE_PASSTHROUGH 1
+#  endif
+#  ifndef FUSE_SUPER_MAGIC
+#   define FUSE_SUPER_MAGIC 0x65735546UL
 #  endif
 # endif
 #endif
@@ -1764,22 +1768,35 @@ static int lopen(const char *path, struct fuse_file_info *fi)
 #ifdef HAVE_FUSE_PASSTHROUGH
         fi->backing_id = 0;
         if (passthrough_enabled) {
-                int backing_id = lpassthrough_open(fd);
-                if (backing_id < 0) {
-                        if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
-                                syslog(LOG_ERR, "cannot enable passthrough for "
-                                       "%s: %s", path,
-                                       strerror(-backing_id));
-                                close(fd);
-                                free(io);
-                                return backing_id;
-                        }
-                        lpassthrough_warn_once(path, -backing_id);
+                /* Skip passthrough when the backing file itself lives on a
+                 * FUSE filesystem (e.g. MergerFS).  The kernel rejects such
+                 * registrations at open-reply time with EIO because the FUSE
+                 * passthrough layer cannot chain another non-passthrough FUSE
+                 * mount as a backing store. */
+                struct statfs sfs;
+                int on_fuse = (fstatfs(fd, &sfs) == 0 &&
+                               sfs.f_type == (long)FUSE_SUPER_MAGIC);
+                if (on_fuse) {
+                        syslog(LOG_DEBUG, "skipping passthrough for FUSE-backed "
+                               "file %s", path);
                 } else {
-                        io->backing_id = backing_id;
-                        fi->backing_id = backing_id;
-                        syslog(LOG_DEBUG, "passthrough backing id %d for %s",
-                               backing_id, path);
+                        int backing_id = lpassthrough_open(fd);
+                        if (backing_id < 0) {
+                                if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
+                                        syslog(LOG_ERR, "cannot enable passthrough for "
+                                               "%s: %s", path,
+                                               strerror(-backing_id));
+                                        close(fd);
+                                        free(io);
+                                        return backing_id;
+                                }
+                                lpassthrough_warn_once(path, -backing_id);
+                        } else {
+                                io->backing_id = backing_id;
+                                fi->backing_id = backing_id;
+                                syslog(LOG_DEBUG, "passthrough backing id %d for %s",
+                                       backing_id, path);
+                        }
                 }
         }
 #endif

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -1793,6 +1793,9 @@ static int lopen_common(const char *path, struct fuse_file_info *fi,
                 } else {
                         io->backing_id = backing_id;
                         fi->backing_id = backing_id;
+                        /* FOPEN_DIRECT_IO takes precedence over
+                         * FOPEN_PASSTHROUGH for read/write requests. */
+                        fi->direct_io = 0;
                         syslog(LOG_DEBUG, "passthrough backing id %d for %s",
                                backing_id, path);
                 }
@@ -4610,7 +4613,8 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
                                         FUSE_BACKING_STACKED_OVER;
                         passthrough_enabled = 1;
                         syslog(LOG_INFO, "FUSE passthrough enabled "
-                               "(backing stack depth %u, FUSE stack depth %u)",
+                               "(stacking=OVER, backing max depth %u, "
+                               "FUSE depth %u)",
                                conn->max_backing_stack_depth,
                                conn->max_backing_stack_depth + 1);
                 } else if (rar2fs_mount_opts.passthrough ==
@@ -4642,8 +4646,22 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
 #if FUSE_MAJOR_VERSION >= 3
 static void *rar2_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
 {
+        void *data = rar2_init_common(conn);
+
+#ifdef HAVE_FUSE_PASSTHROUGH
+        /* The high-level libfuse path applies cfg->direct_io after open() has
+         * returned, overriding the per-file value above.  If left set, the
+         * OPEN reply contains both FOPEN_DIRECT_IO and FOPEN_PASSTHROUGH and
+         * the kernel routes read/write requests back to the daemon. */
+        if (passthrough_enabled && cfg->direct_io) {
+                cfg->direct_io = 0;
+                syslog(LOG_WARNING, "ignoring direct_io mount option because "
+                       "it overrides FUSE passthrough");
+        }
+#else
         (void)cfg;
-        return rar2_init_common(conn);
+#endif
+        return data;
 }
 #else
 static void *rar2_init(struct fuse_conn_info *conn)

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -4702,7 +4702,7 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
                          * passthrough mount).  Libfuse's default of zero makes
                          * those backing registrations fail with ELOOP. */
                         conn->max_backing_stack_depth =
-                                        2;
+                                        FUSE_BACKING_STACKED_OVER;
                         passthrough_enabled = 1;
                         syslog(LOG_INFO, "FUSE passthrough enabled "
                                "(stacking=OVER, backing max depth %u, "

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -41,14 +41,10 @@
 # include <fuse_lowlevel.h>
 # if defined(__linux__) && defined(FUSE_CAP_PASSTHROUGH)
 #  include <sys/ioctl.h>
-#  include <sys/vfs.h>
 #  include <linux/fuse.h>
 #  if defined(FUSE_DEV_IOC_BACKING_OPEN) && \
                 defined(FUSE_DEV_IOC_BACKING_CLOSE)
 #   define HAVE_FUSE_PASSTHROUGH 1
-#  endif
-#  ifndef FUSE_SUPER_MAGIC
-#   define FUSE_SUPER_MAGIC 0x65735546UL
 #  endif
 # endif
 #endif
@@ -1726,13 +1722,21 @@ static int lpassthrough_open(int fd)
         return backing_id;
 }
 
+static const char *lpassthrough_error(int err)
+{
+        if (err == ELOOP)
+                return "backing filesystem stack is already at the kernel "
+                       "maximum depth";
+        return strerror(err);
+}
+
 static void lpassthrough_warn_once(const char *path, int err)
 {
         pthread_mutex_lock(&passthrough_log_lock);
         if (!passthrough_failure_logged) {
                 syslog(LOG_WARNING, "passthrough unavailable for local file "
                        "%s: cannot register backing file: %s",
-                       path, strerror(err));
+                       path, lpassthrough_error(err));
                 passthrough_failure_logged = 1;
         }
         pthread_mutex_unlock(&passthrough_log_lock);
@@ -1753,13 +1757,18 @@ static void lpassthrough_close(int backing_id)
  *****************************************************************************
  *
  ****************************************************************************/
-static int lopen(const char *path, struct fuse_file_info *fi)
+static int lopen_common(const char *path, struct fuse_file_info *fi,
+                mode_t mode, int create)
 {
         ENTER_("%s", path);
         struct io_handle *io = calloc(1, sizeof(struct io_handle));
         if (!io)
                 return -ENOMEM;
-        int fd = open(path, fi->flags);
+        int fd;
+        if (create)
+                fd = open(path, fi->flags | O_CREAT, mode);
+        else
+                fd = open(path, fi->flags);
         if (fd == -1) {
                 free(io);
                 return -errno;
@@ -1768,35 +1777,24 @@ static int lopen(const char *path, struct fuse_file_info *fi)
 #ifdef HAVE_FUSE_PASSTHROUGH
         fi->backing_id = 0;
         if (passthrough_enabled) {
-                /* Skip passthrough when the backing file itself lives on a
-                 * FUSE filesystem (e.g. MergerFS).  The kernel rejects such
-                 * registrations at open-reply time with EIO because the FUSE
-                 * passthrough layer cannot chain another non-passthrough FUSE
-                 * mount as a backing store. */
-                struct statfs sfs;
-                int on_fuse = (fstatfs(fd, &sfs) == 0 &&
-                               sfs.f_type == (long)FUSE_SUPER_MAGIC);
-                if (on_fuse) {
-                        syslog(LOG_DEBUG, "skipping passthrough for FUSE-backed "
-                               "file %s", path);
-                } else {
-                        int backing_id = lpassthrough_open(fd);
-                        if (backing_id < 0) {
-                                if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
-                                        syslog(LOG_ERR, "cannot enable passthrough for "
-                                               "%s: %s", path,
-                                               strerror(-backing_id));
-                                        close(fd);
-                                        free(io);
-                                        return backing_id;
-                                }
-                                lpassthrough_warn_once(path, -backing_id);
-                        } else {
-                                io->backing_id = backing_id;
-                                fi->backing_id = backing_id;
-                                syslog(LOG_DEBUG, "passthrough backing id %d for %s",
-                                       backing_id, path);
+                int backing_id = lpassthrough_open(fd);
+                if (backing_id < 0) {
+                        if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
+                                syslog(LOG_ERR, "cannot enable passthrough for "
+                                       "%s: %s", path,
+                                       lpassthrough_error(-backing_id));
+                                close(fd);
+                                if (create)
+                                        unlink(path);
+                                free(io);
+                                return backing_id;
                         }
+                        lpassthrough_warn_once(path, -backing_id);
+                } else {
+                        io->backing_id = backing_id;
+                        fi->backing_id = backing_id;
+                        syslog(LOG_DEBUG, "passthrough backing id %d for %s",
+                               backing_id, path);
                 }
         }
 #endif
@@ -1806,6 +1804,18 @@ static int lopen(const char *path, struct fuse_file_info *fi)
         FH_SETFD(fi->fh, fd);
         return 0;
 }
+
+static int lopen(const char *path, struct fuse_file_info *fi)
+{
+        return lopen_common(path, fi, 0, 0);
+}
+
+#ifdef HAVE_FUSE_PASSTHROUGH
+static int lcreate(const char *path, mode_t mode, struct fuse_file_info *fi)
+{
+        return lopen_common(path, fi, mode, 1);
+}
+#endif
 
 /*!
  *****************************************************************************
@@ -4356,6 +4366,27 @@ static inline int access_chk(const char *path, int new_file)
         return e && !e->flags.unresolved ? 1 : 0;
 }
 
+#ifdef HAVE_FUSE_PASSTHROUGH
+/* Handle FUSE_CREATE directly so libfuse returns FOPEN_PASSTHROUGH and the
+ * backing ID in the same CREATE reply. */
+static int rar2_create(const char *path, mode_t mode,
+                struct fuse_file_info *fi)
+{
+        char *root;
+        int res;
+
+        ENTER_("%s", path);
+        if (access_chk(path, 1))
+                return -EPERM;
+
+        ABS_ROOT(root, path);
+        res = lcreate(root, mode, fi);
+        if (!res)
+                __dircache_invalidate_for_file(path);
+        return res;
+}
+#endif
+
 /*!
  *****************************************************************************
  *
@@ -4567,6 +4598,9 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
         passthrough_required_unavailable = 0;
         fuse_unset_feature_flag(conn, FUSE_CAP_PASSTHROUGH);
         if (rar2fs_mount_opts.passthrough != PASSTHROUGH_OFF) {
+                /* The kernel refuses the FUSE_PASSTHROUGH and
+                 * FUSE_WRITEBACK_CACHE combination during INIT. */
+                fuse_unset_feature_flag(conn, FUSE_CAP_WRITEBACK_CACHE);
                 if (fuse_set_feature_flag(conn, FUSE_CAP_PASSTHROUGH)) {
                         /* Permit a local backing file to reside on one stacked
                          * filesystem (for example overlayfs or another FUSE
@@ -4576,8 +4610,9 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
                                         FUSE_BACKING_STACKED_OVER;
                         passthrough_enabled = 1;
                         syslog(LOG_INFO, "FUSE passthrough enabled "
-                               "(max backing stack depth %u)",
-                               conn->max_backing_stack_depth);
+                               "(backing stack depth %u, FUSE stack depth %u)",
+                               conn->max_backing_stack_depth,
+                               conn->max_backing_stack_depth + 1);
                 } else if (rar2fs_mount_opts.passthrough ==
                                 PASSTHROUGH_FORCE) {
                         syslog(LOG_ERR, "FUSE passthrough is not supported "
@@ -5677,6 +5712,9 @@ static int work(struct fuse_args *args)
                 rar2_operations.opendir         = rar2_opendir;
                 rar2_operations.readdir         = rar2_readdir;
                 rar2_operations.releasedir      = rar2_releasedir;
+#ifdef HAVE_FUSE_PASSTHROUGH
+                rar2_operations.create          = rar2_create;
+#endif
                 rar2_operations.rename          = rar2_rename;
                 rar2_operations.mknod           = rar2_mknod;
                 rar2_operations.unlink          = rar2_unlink;

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -37,6 +37,17 @@
 #include <errno.h>
 #include <libgen.h>
 #include <fuse.h>
+#if FUSE_MAJOR_VERSION >= 3
+# include <fuse_lowlevel.h>
+# if defined(__linux__) && defined(FUSE_CAP_PASSTHROUGH)
+#  include <sys/ioctl.h>
+#  include <fuse_kernel.h>
+#  if defined(FUSE_DEV_IOC_BACKING_OPEN) && \
+                defined(FUSE_DEV_IOC_BACKING_CLOSE)
+#   define HAVE_FUSE_PASSTHROUGH 1
+#  endif
+# endif
+#endif
 #include <fcntl.h>
 #include <getopt.h>
 #include <syslog.h>
@@ -125,6 +136,9 @@ struct io_handle {
                 uintptr_t bits;
         } u;
         char *path;                             /* type = all */
+#ifdef HAVE_FUSE_PASSTHROUGH
+        int backing_id;                         /* type = IO_TYPE_NRM */
+#endif
 };
 
 #define FH_ZERO(fh)            ((fh) = 0)
@@ -167,6 +181,12 @@ static volatile int warmup_threads = 0;
 static pthread_mutex_t warmup_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t warmup_cond = PTHREAD_COND_INITIALIZER;
 static char *src_path_full = NULL;
+#ifdef HAVE_FUSE_PASSTHROUGH
+static int fuse_dev_fd = -1;
+static int passthrough_enabled = 0;
+static int passthrough_required_unavailable = 0;
+static void lpassthrough_close(int backing_id);
+#endif
 
 #define P_ALIGN_(a) (((a)+page_size_)&~(page_size_-1))
 
@@ -204,7 +224,19 @@ static const char *file_cmd[] = {
 struct rar2fs_mount_opts {
      char *locale;
      int warmup;
+     int passthrough;
 };
+
+#define PASSTHROUGH_AUTO  0
+#define PASSTHROUGH_OFF   1
+#define PASSTHROUGH_FORCE 2
+
+#if FUSE_MAJOR_VERSION >= 3
+# define FUSE_FILL_DIR(f, b, n, s, o) \
+        (f)((b), (n), (s), (o), (enum fuse_fill_dir_flags)0)
+#else
+# define FUSE_FILL_DIR(f, b, n, s, o) (f)((b), (n), (s), (o))
+#endif
 
 #define RAR2FS_MOUNT_OPT(t, p, v) \
         { t, offsetof(struct rar2fs_mount_opts, p), v }
@@ -1619,9 +1651,19 @@ static int lrelease(struct fuse_file_info *fi)
         if (FH_TOIO(fi->fh)->type == IO_TYPE_INFO) {
                 free(FH_TOPATH(fi->fh));
                 free(FH_TOBUF(fi->fh));
+        } else {
+#ifdef HAVE_FUSE_PASSTHROUGH
+                if (FH_TOIO(fi->fh)->type == IO_TYPE_NRM &&
+                                FH_TOIO(fi->fh)->backing_id > 0) {
+                        int backing_id = FH_TOIO(fi->fh)->backing_id;
+                        FH_TOIO(fi->fh)->backing_id = 0;
+                        fi->backing_id = 0;
+                        lpassthrough_close(backing_id);
+                }
+#endif
+                if (FH_TOFD(fi->fh) >= 0)
+                        close(FH_TOFD(fi->fh));
         }
-        else if (FH_TOFD(fi->fh))
-                close(FH_TOFD(fi->fh));
         printd(3, "(%05d) %s [0x%-16" PRIx64 "]\n", getpid(), "FREE", fi->fh);
         free(FH_TOIO(fi->fh));
         FH_ZERO(fi->fh);
@@ -1657,6 +1699,38 @@ static int lread(char *buffer, size_t size, off_t offset,
         return res;
 }
 
+#ifdef HAVE_FUSE_PASSTHROUGH
+/* The high-level libfuse API carries backing_id in fuse_file_info, but the
+ * backing-file registration helpers are exposed only by the low-level API
+ * and require a request handle.  Use the same public kernel ioctl against the
+ * descriptor owned by the high-level session. */
+static int lpassthrough_open(int fd)
+{
+        struct fuse_backing_map map = { .fd = fd };
+        int backing_id;
+
+        if (fuse_dev_fd < 0)
+                return -ENODEV;
+
+        backing_id = ioctl(fuse_dev_fd, FUSE_DEV_IOC_BACKING_OPEN, &map);
+        if (backing_id < 0)
+                return -errno;
+        if (!backing_id)
+                return -EIO;
+        return backing_id;
+}
+
+static void lpassthrough_close(int backing_id)
+{
+        uint32_t id = backing_id;
+
+        if (backing_id > 0 && fuse_dev_fd >= 0 &&
+                        ioctl(fuse_dev_fd, FUSE_DEV_IOC_BACKING_CLOSE, &id))
+                printd(2, "Failed to close passthrough backing id %d: %s\n",
+                       backing_id, strerror(errno));
+}
+#endif
+
 /*!
  *****************************************************************************
  *
@@ -1664,7 +1738,7 @@ static int lread(char *buffer, size_t size, off_t offset,
 static int lopen(const char *path, struct fuse_file_info *fi)
 {
         ENTER_("%s", path);
-        struct io_handle *io = malloc(sizeof(struct io_handle));
+        struct io_handle *io = calloc(1, sizeof(struct io_handle));
         if (!io)
                 return -ENOMEM;
         int fd = open(path, fi->flags);
@@ -1672,6 +1746,26 @@ static int lopen(const char *path, struct fuse_file_info *fi)
                 free(io);
                 return -errno;
         }
+
+#ifdef HAVE_FUSE_PASSTHROUGH
+        fi->backing_id = 0;
+        if (passthrough_enabled) {
+                int backing_id = lpassthrough_open(fd);
+                if (backing_id < 0) {
+                        if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
+                                close(fd);
+                                free(io);
+                                return backing_id;
+                        }
+                        printd(2, "Passthrough unavailable for %s: %s\n",
+                               path, error_to_string(-backing_id));
+                } else {
+                        io->backing_id = backing_id;
+                        fi->backing_id = backing_id;
+                }
+        }
+#endif
+
         FH_SETIO(fi->fh, io);
         FH_SETTYPE(fi->fh, IO_TYPE_NRM);
         FH_SETFD(fi->fh, fd);
@@ -3199,10 +3293,17 @@ static int syncrar(const char *path)
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_getattr(const char *path, struct stat *stbuf)
+static int rar2_getattr(const char *path, struct stat *stbuf
+#if FUSE_MAJOR_VERSION >= 3
+                , struct fuse_file_info *fi
+#endif
+                )
 {
         ENTER_("%s", path);
 
+#if FUSE_MAJOR_VERSION >= 3
+        (void)fi;
+#endif
         struct filecache_entry *entry_p;
 
         pthread_rwlock_rdlock(&file_access_lock);
@@ -3277,10 +3378,17 @@ static int rar2_getattr(const char *path, struct stat *stbuf)
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_getattr2(const char *path, struct stat *stbuf)
+static int rar2_getattr2(const char *path, struct stat *stbuf
+#if FUSE_MAJOR_VERSION >= 3
+                , struct fuse_file_info *fi
+#endif
+                )
 {
         ENTER_("%s", path);
 
+#if FUSE_MAJOR_VERSION >= 3
+        (void)fi;
+#endif
         int res;
 
         pthread_rwlock_rdlock(&file_access_lock);
@@ -3363,7 +3471,8 @@ static void dump_dir_list(const char *path, void *buffer, fuse_fill_dir_t filler
                  * the directory cache is currently in effect.
                  */
                 if (next->entry.valid) {
-                        filler(buffer, next->entry.name, next->entry.st, 0);
+                        FUSE_FILL_DIR(filler, buffer, next->entry.name,
+                                      next->entry.st, 0);
 /* TODO: If/when folder cache becomes optional this needs to be revisted */
 #if 0
                         if (next->entry.type == DIR_E_RAR)
@@ -3448,12 +3557,19 @@ opendir_ok:
  *
  ****************************************************************************/
 static int rar2_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
-                off_t offset, struct fuse_file_info *fi)
+                off_t offset, struct fuse_file_info *fi
+#if FUSE_MAJOR_VERSION >= 3
+                , enum fuse_readdir_flags flags
+#endif
+                )
 {
         ENTER_("%s", (path ? path : ""));
 
         int ret = 0;
         (void)offset;           /* touch */
+#if FUSE_MAJOR_VERSION >= 3
+        (void)flags;
+#endif
 
         assert(FH_ISSET(fi->fh) && "bad I/O handle");
 
@@ -3527,8 +3643,8 @@ static int rar2_readdir(const char *path, void *buffer, fuse_fill_dir_t filler,
 dump_buff:
 
         if (dp == NULL) {
-                filler(buffer, ".", NULL, 0);
-                filler(buffer, "..", NULL, 0);
+                FUSE_FILL_DIR(filler, buffer, ".", NULL, 0);
+                FUSE_FILL_DIR(filler, buffer, "..", NULL, 0);
         }
 
         (void)dir_list_append(&dir_list, dir_list2);
@@ -3570,11 +3686,18 @@ dump_buff_nocache:
  ****************************************************************************/
 static int rar2_readdir2(const char *path, void *buffer,
                 fuse_fill_dir_t filler, off_t offset,
-                struct fuse_file_info *fi)
+                struct fuse_file_info *fi
+#if FUSE_MAJOR_VERSION >= 3
+                , enum fuse_readdir_flags flags
+#endif
+                )
 {
         ENTER_("%s", (path ? path : ""));
 
         (void)offset;           /* touch */
+#if FUSE_MAJOR_VERSION >= 3
+        (void)flags;
+#endif
 
         struct dir_entry_list *dir_list; /* internal list root */
 
@@ -3612,8 +3735,8 @@ static int rar2_readdir2(const char *path, void *buffer,
                 pthread_rwlock_unlock(&dir_access_lock);
         }
 
-        filler(buffer, ".", NULL, 0);
-        filler(buffer, "..", NULL, 0);
+        FUSE_FILL_DIR(filler, buffer, ".", NULL, 0);
+        FUSE_FILL_DIR(filler, buffer, "..", NULL, 0);
 
         dir_list_close(dir_list);
         dump_dir_list(FH_TOPATH(fi->fh), buffer, filler, dir_list);
@@ -4391,12 +4514,30 @@ static struct dircache_cb dircache_cb = {
  *****************************************************************************
  *
  ****************************************************************************/
-static void *rar2_init(struct fuse_conn_info *conn)
+static void *rar2_init_common(struct fuse_conn_info *conn)
 {
         ENTER_();
 
         pthread_t t;
-        (void)conn;             /* touch */
+
+#ifdef HAVE_FUSE_PASSTHROUGH
+        passthrough_enabled = 0;
+        passthrough_required_unavailable = 0;
+        fuse_unset_feature_flag(conn, FUSE_CAP_PASSTHROUGH);
+        if (rar2fs_mount_opts.passthrough != PASSTHROUGH_OFF) {
+                if (fuse_set_feature_flag(conn, FUSE_CAP_PASSTHROUGH)) {
+                        passthrough_enabled = 1;
+                } else if (rar2fs_mount_opts.passthrough ==
+                                PASSTHROUGH_FORCE) {
+                        fprintf(stderr, "rar2fs: FUSE passthrough is not "
+                                        "supported by this kernel\n");
+                        passthrough_required_unavailable = 1;
+                        fuse_exit(fuse_get_context()->fuse);
+                }
+        }
+#else
+        (void)conn;
+#endif
 
         filecache_init();
         dircache_init(&dircache_cb);
@@ -4407,6 +4548,19 @@ static void *rar2_init(struct fuse_conn_info *conn)
 
         return NULL;
 }
+
+#if FUSE_MAJOR_VERSION >= 3
+static void *rar2_init(struct fuse_conn_info *conn, struct fuse_config *cfg)
+{
+        (void)cfg;
+        return rar2_init_common(conn);
+}
+#else
+static void *rar2_init(struct fuse_conn_info *conn)
+{
+        return rar2_init_common(conn);
+}
+#endif
 
 /*!
  *****************************************************************************
@@ -4615,9 +4769,16 @@ static int rar2_read(const char *path, char *buffer, size_t size, off_t offset,
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_truncate(const char *path, off_t offset)
+static int rar2_truncate(const char *path, off_t offset
+#if FUSE_MAJOR_VERSION >= 3
+                , struct fuse_file_info *fi
+#endif
+                )
 {
         ENTER_("%s", path);
+#if FUSE_MAJOR_VERSION >= 3
+        (void)fi;
+#endif
         if (!access_chk(path, 0)) {
                 char *root;
                 ABS_ROOT(root, path);
@@ -4649,9 +4810,16 @@ static int rar2_write(const char *path, const char *buffer, size_t size,
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_chmod(const char *path, mode_t mode)
+static int rar2_chmod(const char *path, mode_t mode
+#if FUSE_MAJOR_VERSION >= 3
+                , struct fuse_file_info *fi
+#endif
+                )
 {
         ENTER_("%s", path);
+#if FUSE_MAJOR_VERSION >= 3
+        (void)fi;
+#endif
         if (!access_chk(path, 0)) {
                 char *root;
                 ABS_ROOT(root, path);
@@ -4666,9 +4834,16 @@ static int rar2_chmod(const char *path, mode_t mode)
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_chown(const char *path, uid_t uid, gid_t gid)
+static int rar2_chown(const char *path, uid_t uid, gid_t gid
+#if FUSE_MAJOR_VERSION >= 3
+                , struct fuse_file_info *fi
+#endif
+                )
 {
         ENTER_("%s", path);
+#if FUSE_MAJOR_VERSION >= 3
+        (void)fi;
+#endif
         if (!access_chk(path, 0)) {
                 char *root;
                 ABS_ROOT(root, path);
@@ -4692,10 +4867,18 @@ static int rar2_eperm()
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_rename(const char *oldpath, const char *newpath)
+static int rar2_rename(const char *oldpath, const char *newpath
+#if FUSE_MAJOR_VERSION >= 3
+                , unsigned int flags
+#endif
+                )
 {
         ENTER_("%s", oldpath);
 
+#if FUSE_MAJOR_VERSION >= 3
+        if (flags)
+                return -EINVAL;
+#endif
         /* We can not move things out of- or from RAR archives */
         if (!access_chk(newpath, 0) && !access_chk(oldpath, 0)) {
                 char *oldroot;
@@ -4790,10 +4973,17 @@ static int rar2_rmdir(const char *path)
  *****************************************************************************
  *
  ****************************************************************************/
-static int rar2_utimens(const char *path, const struct timespec ts[2])
+static int rar2_utimens(const char *path, const struct timespec ts[2]
+#if FUSE_MAJOR_VERSION >= 3
+                , struct fuse_file_info *fi
+#endif
+                )
 {
         ENTER_("%s", path);
 
+#if FUSE_MAJOR_VERSION >= 3
+        (void)fi;
+#endif
         struct stat st;
 
         if (!access_chk(path, 0)) {
@@ -5289,7 +5479,7 @@ static struct fuse_operations rar2_operations = {
 #if FUSE_MAJOR_VERSION == 2 && FUSE_MINOR_VERSION > 7
         .flag_nullpath_ok = 1,
 #endif
-#if FUSE_MAJOR_VERSION > 2 || (FUSE_MAJOR_VERSION == 2 && FUSE_MINOR_VERSION >= 9)
+#if FUSE_MAJOR_VERSION == 2 && FUSE_MINOR_VERSION >= 9
         .flag_nopath = 1,
 #endif
 };
@@ -5297,6 +5487,7 @@ static struct fuse_operations rar2_operations = {
 struct work_task_data {
         struct fuse *fuse;
         int mt;
+        int clone_fd;
         volatile int work_task_exited;
         int status;
 };
@@ -5308,7 +5499,19 @@ struct work_task_data {
 static void *work_task(void *data)
 {
         struct work_task_data *wdt = (struct work_task_data *)data;
-        wdt->status = wdt->mt ? fuse_loop_mt(wdt->fuse) : fuse_loop(wdt->fuse);
+        if (!wdt->mt) {
+                wdt->status = fuse_loop(wdt->fuse);
+        } else {
+#if FUSE_MAJOR_VERSION >= 3
+# if FUSE_USE_VERSION < 32
+                wdt->status = fuse_loop_mt(wdt->fuse, wdt->clone_fd);
+# else
+                wdt->status = fuse_loop_mt(wdt->fuse, NULL);
+# endif
+#else
+                wdt->status = fuse_loop_mt(wdt->fuse);
+#endif
+        }
         wdt->work_task_exited = 1;
         return NULL;
 }
@@ -5446,13 +5649,19 @@ static int work(struct fuse_args *args)
         }
 
         struct fuse *f = NULL;
+#if FUSE_MAJOR_VERSION == 2
         struct fuse_chan *ch = NULL;
+#else
+        struct fuse_cmdline_opts opts;
+        memset(&opts, 0, sizeof(opts));
+#endif
         pthread_t t;
         char *mp;
         int mt = 0;
         int fg = 0;
 
         /* This is doing more or less the same as fuse_setup(). */
+#if FUSE_MAJOR_VERSION == 2
         if (!fuse_parse_cmdline(args, &mp, &mt, &fg)) {
               ch = fuse_mount(mp, args);
               if (ch) {
@@ -5478,12 +5687,51 @@ static int work(struct fuse_args *args)
                       }
               }
         }
+#else
+        if (!fuse_parse_cmdline(args, &opts)) {
+                mp = opts.mountpoint;
+                mt = !opts.singlethread;
+                fg = opts.foreground;
 
-        if (f == NULL)
+                /* Avoid any output from the initial attempt. */
+                block_stdio();
+                f = fuse_new(args, &rar2_operations,
+                             sizeof(rar2_operations), NULL);
+                release_stdio();
+                if (f == NULL) {
+                        (void)scan_fuse_new_args(args);
+                        f = fuse_new(args, &rar2_operations,
+                                     sizeof(rar2_operations), NULL);
+                }
+                if (f != NULL && fuse_mount(f, mp)) {
+                        fuse_destroy(f);
+                        f = NULL;
+                }
+                if (f != NULL) {
+#ifdef HAVE_FUSE_PASSTHROUGH
+                        fuse_dev_fd = fuse_session_fd(fuse_get_session(f));
+#endif
+                        fuse_daemonize(fg);
+                        fuse_set_signal_handlers(fuse_get_session(f));
+                        syslog(LOG_DEBUG, "mounted %s", mp);
+                }
+        }
+#endif
+
+        if (f == NULL) {
+#if FUSE_MAJOR_VERSION >= 3
+                free(opts.mountpoint);
+#endif
                 return -1;
+        }
 
         wdt.fuse = f;
         wdt.mt = mt;
+#if FUSE_MAJOR_VERSION >= 3
+        wdt.clone_fd = opts.clone_fd;
+#else
+        wdt.clone_fd = 0;
+#endif
         wdt.work_task_exited = 0;
         wdt.status = 0;
         pthread_create(&t, &thread_attr, work_task, (void *)&wdt);
@@ -5494,7 +5742,13 @@ static int work(struct fuse_args *args)
          * But this is really what we want since this thread should not
          * block blindly without some user control.
          */
-        while (!fuse_exited(f) && !wdt.work_task_exited) {
+        while (
+#if FUSE_MAJOR_VERSION >= 3
+                        !fuse_session_exited(fuse_get_session(f)) &&
+#else
+                        !fuse_exited(f) &&
+#endif
+                        !wdt.work_task_exited) {
                 sleep(1);
                 ++rar2_ticks;
         }
@@ -5504,11 +5758,23 @@ static int work(struct fuse_args *args)
         fs_terminated = 1;
         warmup_cancelled = 1;
         pthread_join(t, NULL);
+#ifdef HAVE_FUSE_PASSTHROUGH
+        if (passthrough_required_unavailable)
+                wdt.status = -ENOTSUP;
+#endif
 
         /* This is doing more or less the same as fuse_teardown(). */
         fuse_remove_signal_handlers(fuse_get_session(f));
+#if FUSE_MAJOR_VERSION == 2
         fuse_unmount(mp, ch);
+#else
+        fuse_unmount(f);
+#endif
         fuse_destroy(f);
+#ifdef HAVE_FUSE_PASSTHROUGH
+        fuse_dev_fd = -1;
+        passthrough_enabled = 0;
+#endif
         syslog(LOG_DEBUG, "unmounted %s", mp);
         free(mp);
 
@@ -5577,6 +5843,7 @@ static void print_help()
         printf("    -o locale=LOCALE        set the locale for file names (default: according to LC_*/LC_CTYPE)\n");
 #endif
         printf("    -o warmup[=THREADS]     start background cache warmup threads (default: 5)\n");
+        printf("    -o passthrough=MODE     local-file I/O: off, auto, or force (default: auto)\n");
 }
 
 /* FUSE API specific keys continue where 'optdb' left off */
@@ -5591,6 +5858,9 @@ static struct fuse_opt rar2fs_opts[] = {
 #endif
         RAR2FS_MOUNT_OPT("warmup=%d", warmup, 0),
         RAR2FS_MOUNT_OPT("warmup", warmup, 5),
+        RAR2FS_MOUNT_OPT("passthrough=auto", passthrough, PASSTHROUGH_AUTO),
+        RAR2FS_MOUNT_OPT("passthrough=off", passthrough, PASSTHROUGH_OFF),
+        RAR2FS_MOUNT_OPT("passthrough=force", passthrough, PASSTHROUGH_FORCE),
 
         FUSE_OPT_KEY("-V",              OPT_KEY_VERSION),
         FUSE_OPT_KEY("--version",       OPT_KEY_VERSION),
@@ -5728,6 +5998,16 @@ int main(int argc, char *argv[])
         if (fuse_opt_parse(&args, &rar2fs_mount_opts, rar2fs_opts,
                            rar2fs_opt_proc))
                 return -1;
+
+#ifndef HAVE_FUSE_PASSTHROUGH
+        if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
+                fprintf(stderr, "%s: passthrough=force requires libfuse3 "
+                                ">= 3.17.1 on Linux\n", argv[0]);
+                fuse_opt_free_args(&args);
+                optdb_destroy();
+                return -1;
+        }
+#endif
 
         /* Check src/dst path */
         if (OPT_SET(OPT_KEY_SRC) && OPT_SET(OPT_KEY_DST)) {

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -4520,6 +4520,13 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
 
         pthread_t t;
 
+#if FUSE_MAJOR_VERSION >= 3
+        /* The libfuse3 high-level fuse_new path does not consume sync_read.
+         * Preserve rar2fs's existing synchronous-read behavior through the
+         * connection capability API instead. */
+        fuse_unset_feature_flag(conn, FUSE_CAP_ASYNC_READ);
+#endif
+
 #ifdef HAVE_FUSE_PASSTHROUGH
         passthrough_enabled = 0;
         passthrough_required_unavailable = 0;
@@ -5693,16 +5700,8 @@ static int work(struct fuse_args *args)
                 mt = !opts.singlethread;
                 fg = opts.foreground;
 
-                /* Avoid any output from the initial attempt. */
-                block_stdio();
                 f = fuse_new(args, &rar2_operations,
                              sizeof(rar2_operations), NULL);
-                release_stdio();
-                if (f == NULL) {
-                        (void)scan_fuse_new_args(args);
-                        f = fuse_new(args, &rar2_operations,
-                                     sizeof(rar2_operations), NULL);
-                }
                 if (f != NULL && fuse_mount(f, mp)) {
                         fuse_destroy(f);
                         f = NULL;
@@ -6045,7 +6044,11 @@ int main(int argc, char *argv[])
                         return -1;
         }
 
+#if FUSE_MAJOR_VERSION >= 3
+        fuse_opt_add_arg(&args, "-ofsname=rar2fs,subtype=rar2fs");
+#else
         fuse_opt_add_arg(&args, "-osync_read,fsname=rar2fs,subtype=rar2fs");
+#endif
         if (OPT_SET(OPT_KEY_DST))
                 fuse_opt_add_arg(&args, OPT_STR(OPT_KEY_DST, 0));
 

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -185,6 +185,8 @@ static char *src_path_full = NULL;
 static int fuse_dev_fd = -1;
 static int passthrough_enabled = 0;
 static int passthrough_required_unavailable = 0;
+static int passthrough_failure_logged = 0;
+static pthread_mutex_t passthrough_log_lock = PTHREAD_MUTEX_INITIALIZER;
 static void lpassthrough_close(int backing_id);
 #endif
 
@@ -1720,6 +1722,18 @@ static int lpassthrough_open(int fd)
         return backing_id;
 }
 
+static void lpassthrough_warn_once(const char *path, int err)
+{
+        pthread_mutex_lock(&passthrough_log_lock);
+        if (!passthrough_failure_logged) {
+                syslog(LOG_WARNING, "passthrough unavailable for local file "
+                       "%s: cannot register backing file: %s",
+                       path, strerror(err));
+                passthrough_failure_logged = 1;
+        }
+        pthread_mutex_unlock(&passthrough_log_lock);
+}
+
 static void lpassthrough_close(int backing_id)
 {
         uint32_t id = backing_id;
@@ -1753,15 +1767,19 @@ static int lopen(const char *path, struct fuse_file_info *fi)
                 int backing_id = lpassthrough_open(fd);
                 if (backing_id < 0) {
                         if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
+                                syslog(LOG_ERR, "cannot enable passthrough for "
+                                       "%s: %s", path,
+                                       strerror(-backing_id));
                                 close(fd);
                                 free(io);
                                 return backing_id;
                         }
-                        printd(2, "Passthrough unavailable for %s: %s\n",
-                               path, error_to_string(-backing_id));
+                        lpassthrough_warn_once(path, -backing_id);
                 } else {
                         io->backing_id = backing_id;
                         fi->backing_id = backing_id;
+                        syslog(LOG_DEBUG, "passthrough backing id %d for %s",
+                               backing_id, path);
                 }
         }
 #endif
@@ -4533,13 +4551,26 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
         fuse_unset_feature_flag(conn, FUSE_CAP_PASSTHROUGH);
         if (rar2fs_mount_opts.passthrough != PASSTHROUGH_OFF) {
                 if (fuse_set_feature_flag(conn, FUSE_CAP_PASSTHROUGH)) {
+                        /* Permit a local backing file to reside on one stacked
+                         * filesystem (for example overlayfs or another FUSE
+                         * passthrough mount).  Libfuse's default of zero makes
+                         * those backing registrations fail with ELOOP. */
+                        conn->max_backing_stack_depth =
+                                        FUSE_BACKING_STACKED_OVER;
                         passthrough_enabled = 1;
+                        syslog(LOG_INFO, "FUSE passthrough enabled "
+                               "(max backing stack depth %u)",
+                               conn->max_backing_stack_depth);
                 } else if (rar2fs_mount_opts.passthrough ==
                                 PASSTHROUGH_FORCE) {
-                        fprintf(stderr, "rar2fs: FUSE passthrough is not "
-                                        "supported by this kernel\n");
+                        syslog(LOG_ERR, "FUSE passthrough is not supported "
+                               "by this kernel");
                         passthrough_required_unavailable = 1;
                         fuse_exit(fuse_get_context()->fuse);
+                } else {
+                        syslog(LOG_WARNING, "FUSE passthrough unavailable: "
+                               "the kernel did not advertise support; "
+                               "using normal FUSE I/O");
                 }
         }
 #else
@@ -5527,6 +5558,7 @@ static void *work_task(void *data)
  *****************************************************************************
  *
  ****************************************************************************/
+#if FUSE_MAJOR_VERSION == 2
 static void scan_fuse_new_args(struct fuse_args *args)
 {
         const char *match_w_arg = "subtype=rar2fs";
@@ -5595,6 +5627,7 @@ static void release_stdio()
                 stderr_ = 0;
         }
 }
+#endif
 
 /*!
  *****************************************************************************
@@ -5809,6 +5842,11 @@ static void print_version()
         printf("This program comes with ABSOLUTELY NO WARRANTY.\n"
                "This is free software, and you are welcome to redistribute it under\n"
                "certain conditions; see <http://www.gnu.org/licenses/> for details.\n");
+#ifdef HAVE_FUSE_PASSTHROUGH
+        printf("FUSE passthrough support: compiled in\n");
+#else
+        printf("FUSE passthrough support: unavailable at build time\n");
+#endif
 }
 
 /*!

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -4702,7 +4702,7 @@ static void *rar2_init_common(struct fuse_conn_info *conn)
                          * passthrough mount).  Libfuse's default of zero makes
                          * those backing registrations fail with ELOOP. */
                         conn->max_backing_stack_depth =
-                                        FUSE_BACKING_STACKED_OVER;
+                                        2;
                         passthrough_enabled = 1;
                         syslog(LOG_INFO, "FUSE passthrough enabled "
                                "(stacking=OVER, backing max depth %u, "

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -121,6 +121,10 @@ struct io_context {
 #endif
 };
 
+#ifdef HAVE_FUSE_PASSTHROUGH
+struct passthrough_backing;
+#endif
+
 struct io_handle {
         int type;
 #define IO_TYPE_NRM 0
@@ -137,7 +141,7 @@ struct io_handle {
         } u;
         char *path;                             /* type = all */
 #ifdef HAVE_FUSE_PASSTHROUGH
-        int backing_id;                         /* type = IO_TYPE_NRM */
+        struct passthrough_backing *backing;    /* type = IO_TYPE_NRM */
 #endif
 };
 
@@ -182,12 +186,22 @@ static pthread_mutex_t warmup_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t warmup_cond = PTHREAD_COND_INITIALIZER;
 static char *src_path_full = NULL;
 #ifdef HAVE_FUSE_PASSTHROUGH
+struct passthrough_backing {
+        dev_t dev;
+        ino_t ino;
+        int backing_id;
+        unsigned int refs;
+        struct passthrough_backing *next;
+};
+
 static int fuse_dev_fd = -1;
 static int passthrough_enabled = 0;
 static int passthrough_required_unavailable = 0;
 static int passthrough_failure_logged = 0;
+static struct passthrough_backing *passthrough_backings = NULL;
+static pthread_mutex_t passthrough_backing_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_mutex_t passthrough_log_lock = PTHREAD_MUTEX_INITIALIZER;
-static void lpassthrough_close(int backing_id);
+static void lpassthrough_put(struct passthrough_backing *backing);
 #endif
 
 #define P_ALIGN_(a) (((a)+page_size_)&~(page_size_-1))
@@ -1656,11 +1670,12 @@ static int lrelease(struct fuse_file_info *fi)
         } else {
 #ifdef HAVE_FUSE_PASSTHROUGH
                 if (FH_TOIO(fi->fh)->type == IO_TYPE_NRM &&
-                                FH_TOIO(fi->fh)->backing_id > 0) {
-                        int backing_id = FH_TOIO(fi->fh)->backing_id;
-                        FH_TOIO(fi->fh)->backing_id = 0;
+                                FH_TOIO(fi->fh)->backing) {
+                        struct passthrough_backing *backing =
+                                        FH_TOIO(fi->fh)->backing;
+                        FH_TOIO(fi->fh)->backing = NULL;
                         fi->backing_id = 0;
-                        lpassthrough_close(backing_id);
+                        lpassthrough_put(backing);
                 }
 #endif
                 if (FH_TOFD(fi->fh) >= 0)
@@ -1751,6 +1766,79 @@ static void lpassthrough_close(int backing_id)
                 printd(2, "Failed to close passthrough backing id %d: %s\n",
                        backing_id, strerror(errno));
 }
+
+/* The kernel requires every overlapping passthrough open of the same FUSE
+ * inode to use the same registered backing object.  A new BACKING_OPEN ioctl
+ * creates a distinct object even when its fd refers to the same local file,
+ * so share one backing ID for each backing inode until its last handle is
+ * released. */
+static int lpassthrough_get(int fd, struct passthrough_backing **backing_p)
+{
+        struct passthrough_backing *backing;
+        struct stat st;
+        int backing_id;
+
+        *backing_p = NULL;
+        if (fstat(fd, &st))
+                return -errno;
+
+        pthread_mutex_lock(&passthrough_backing_lock);
+        for (backing = passthrough_backings; backing; backing = backing->next) {
+                if (backing->dev == st.st_dev && backing->ino == st.st_ino) {
+                        backing->refs++;
+                        backing_id = backing->backing_id;
+                        *backing_p = backing;
+                        pthread_mutex_unlock(&passthrough_backing_lock);
+                        return backing_id;
+                }
+        }
+
+        backing = malloc(sizeof(*backing));
+        if (!backing) {
+                pthread_mutex_unlock(&passthrough_backing_lock);
+                return -ENOMEM;
+        }
+
+        backing_id = lpassthrough_open(fd);
+        backing->dev = st.st_dev;
+        backing->ino = st.st_ino;
+        backing->backing_id = backing_id;
+        backing->refs = 1;
+        backing->next = passthrough_backings;
+        passthrough_backings = backing;
+        *backing_p = backing;
+        pthread_mutex_unlock(&passthrough_backing_lock);
+        return backing_id;
+}
+
+static void lpassthrough_put(struct passthrough_backing *backing)
+{
+        struct passthrough_backing **link;
+        int backing_id;
+        int found = 0;
+
+        pthread_mutex_lock(&passthrough_backing_lock);
+        for (link = &passthrough_backings; *link; link = &(*link)->next) {
+                if (*link != backing)
+                        continue;
+                if (--(*link)->refs) {
+                        pthread_mutex_unlock(&passthrough_backing_lock);
+                        return;
+                }
+                *link = backing->next;
+                found = 1;
+                break;
+        }
+        pthread_mutex_unlock(&passthrough_backing_lock);
+
+        if (!found)
+                return;
+
+        backing_id = backing->backing_id;
+        if (backing_id > 0)
+                lpassthrough_close(backing_id);
+        free(backing);
+}
 #endif
 
 /*!
@@ -1777,12 +1865,16 @@ static int lopen_common(const char *path, struct fuse_file_info *fi,
 #ifdef HAVE_FUSE_PASSTHROUGH
         fi->backing_id = 0;
         if (passthrough_enabled) {
-                int backing_id = lpassthrough_open(fd);
+                struct passthrough_backing *backing;
+                int backing_id = lpassthrough_get(fd, &backing);
                 if (backing_id < 0) {
-                        if (rar2fs_mount_opts.passthrough == PASSTHROUGH_FORCE) {
+                        if (!backing || rar2fs_mount_opts.passthrough ==
+                                        PASSTHROUGH_FORCE) {
                                 syslog(LOG_ERR, "cannot enable passthrough for "
                                        "%s: %s", path,
                                        lpassthrough_error(-backing_id));
+                                if (backing)
+                                        lpassthrough_put(backing);
                                 close(fd);
                                 if (create)
                                         unlink(path);
@@ -1791,7 +1883,6 @@ static int lopen_common(const char *path, struct fuse_file_info *fi,
                         }
                         lpassthrough_warn_once(path, -backing_id);
                 } else {
-                        io->backing_id = backing_id;
                         fi->backing_id = backing_id;
                         /* FOPEN_DIRECT_IO takes precedence over
                          * FOPEN_PASSTHROUGH for read/write requests. */
@@ -1799,6 +1890,7 @@ static int lopen_common(const char *path, struct fuse_file_info *fi,
                         syslog(LOG_DEBUG, "passthrough backing id %d for %s",
                                backing_id, path);
                 }
+                io->backing = backing;
         }
 #endif
 

--- a/src/rar2fs.c
+++ b/src/rar2fs.c
@@ -41,7 +41,7 @@
 # include <fuse_lowlevel.h>
 # if defined(__linux__) && defined(FUSE_CAP_PASSTHROUGH)
 #  include <sys/ioctl.h>
-#  include <fuse_kernel.h>
+#  include <linux/fuse.h>
 #  if defined(FUSE_DEV_IOC_BACKING_OPEN) && \
                 defined(FUSE_DEV_IOC_BACKING_CLOSE)
 #   define HAVE_FUSE_PASSTHROUGH 1

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,0 +1,4 @@
+TESTS = passthrough.sh
+EXTRA_DIST = $(TESTS)
+
+TESTS_ENVIRONMENT = RAR2FS='$(abs_top_builddir)/src/rar2fs'; export RAR2FS;

--- a/tests/passthrough.sh
+++ b/tests/passthrough.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+
+# Exercise both sides of the open-path decision: ordinary local files must use
+# passthrough in force mode, while members supplied by an archive must continue
+# through rar2fs extraction I/O.  Exit 77 when the host cannot run FUSE
+# passthrough integration tests.
+
+set -u
+
+RAR2FS=${RAR2FS:-../src/rar2fs}
+RAR=${RAR:-rar}
+
+skip()
+{
+        echo "SKIP: $*"
+        exit 77
+}
+
+command -v "$RAR" >/dev/null 2>&1 || skip "rar command is not installed"
+command -v fusermount3 >/dev/null 2>&1 || skip "fusermount3 is not installed"
+command -v mountpoint >/dev/null 2>&1 || skip "mountpoint is not installed"
+test -c /dev/fuse || skip "/dev/fuse is not available"
+test -x "$RAR2FS" || skip "rar2fs has not been built"
+
+tmp=${TMPDIR:-/tmp}/rar2fs-passthrough.$$
+src=$tmp/source
+archive_src=$tmp/archive-source
+mnt=$tmp/mount
+log=$tmp/rar2fs.log
+pid=
+
+cleanup()
+{
+        if mountpoint -q "$mnt" 2>/dev/null; then
+                fusermount3 -u "$mnt" >/dev/null 2>&1 || true
+        fi
+        if test -n "$pid" && kill -0 "$pid" 2>/dev/null; then
+                kill "$pid" 2>/dev/null || true
+        fi
+        test -z "$pid" || wait "$pid" 2>/dev/null || true
+        rm -rf "$tmp"
+}
+trap cleanup EXIT HUP INT TERM
+
+mkdir -p "$src" "$archive_src" "$mnt"
+printf '%s\n' local-before >"$src/local.txt"
+printf '%s\n' archive-data >"$archive_src/archived.txt"
+(cd "$archive_src" && "$RAR" a -idq "$src/content.rar" archived.txt) || exit 1
+
+"$RAR2FS" "$src" "$mnt" -f -o passthrough=force >"$log" 2>&1 &
+pid=$!
+
+i=0
+while ! mountpoint -q "$mnt" 2>/dev/null; do
+        if ! kill -0 "$pid" 2>/dev/null; then
+                if grep -Eqi 'not supported|requires libfuse3|operation not permitted|/dev/fuse' "$log"; then
+                        skip "FUSE passthrough is not supported by this host"
+                fi
+                cat "$log" >&2
+                exit 1
+        fi
+        i=$((i + 1))
+        test "$i" -lt 100 || skip "mount did not become ready"
+        sleep 0.1
+done
+
+printf '%s\n' local-before | cmp - "$mnt/local.txt" || exit 1
+printf '%s\n' local-after >"$mnt/local.txt" || exit 1
+printf '%s\n' local-after | cmp - "$src/local.txt" || exit 1
+
+# There is no local archived.txt in the source tree.  A successful read here
+# therefore verifies that force mode does not try to register archive handles
+# as passthrough backing files.
+printf '%s\n' archive-data | cmp - "$mnt/archived.txt" || exit 1
+
+exit 0

--- a/tests/passthrough.sh
+++ b/tests/passthrough.sh
@@ -50,7 +50,10 @@ dd if=/dev/urandom of="$src/local.bin" bs=1M count=2 >/dev/null 2>&1 || exit 1
 printf '%s\n' archive-data >"$archive_src/archived.txt"
 (cd "$archive_src" && "$RAR" a -idq "$src/content.rar" archived.txt) || exit 1
 
-"$RAR2FS" "$src" "$mnt" -f -d -o passthrough=force >"$log" 2>&1 &
+# Deliberately include direct_io: rar2fs must suppress the global libfuse flag
+# after negotiating passthrough, because the kernel gives FOPEN_DIRECT_IO
+# precedence over FOPEN_PASSTHROUGH for reads and writes.
+"$RAR2FS" "$src" "$mnt" -f -d -o passthrough=force,direct_io >"$log" 2>&1 &
 pid=$!
 
 i=0

--- a/tests/passthrough.sh
+++ b/tests/passthrough.sh
@@ -27,6 +27,8 @@ src=$tmp/source
 archive_src=$tmp/archive-source
 mnt=$tmp/mount
 log=$tmp/rar2fs.log
+local_log=$tmp/local.log
+archive_log=$tmp/archive.log
 pid=
 
 cleanup()
@@ -43,11 +45,11 @@ cleanup()
 trap cleanup EXIT HUP INT TERM
 
 mkdir -p "$src" "$archive_src" "$mnt"
-printf '%s\n' local-before >"$src/local.txt"
+dd if=/dev/urandom of="$src/local.bin" bs=1M count=2 >/dev/null 2>&1 || exit 1
 printf '%s\n' archive-data >"$archive_src/archived.txt"
 (cd "$archive_src" && "$RAR" a -idq "$src/content.rar" archived.txt) || exit 1
 
-"$RAR2FS" "$src" "$mnt" -f -o passthrough=force >"$log" 2>&1 &
+"$RAR2FS" "$src" "$mnt" -f -d -o passthrough=force >"$log" 2>&1 &
 pid=$!
 
 i=0
@@ -64,13 +66,36 @@ while ! mountpoint -q "$mnt" 2>/dev/null; do
         sleep 0.1
 done
 
-printf '%s\n' local-before | cmp - "$mnt/local.txt" || exit 1
-printf '%s\n' local-after >"$mnt/local.txt" || exit 1
-printf '%s\n' local-after | cmp - "$src/local.txt" || exit 1
+# Read a local file through cp.  A registered passthrough handle must keep the
+# READ request in the kernel instead of dispatching it to the rar2fs daemon.
+log_offset=$(( $(wc -c <"$log") + 1 ))
+cp "$mnt/local.bin" "$tmp/local-copy.bin" || exit 1
+cmp "$src/local.bin" "$tmp/local-copy.bin" || exit 1
+sleep 1
+tail -c +"$log_offset" "$log" >"$local_log"
+if ! grep -Eq 'passthrough backing id [1-9][0-9]* for .*local\.bin' \
+                "$local_log"; then
+        echo "local file was not registered as a passthrough backing file" >&2
+        cat "$local_log" >&2
+        exit 1
+fi
+if grep -q 'opcode: READ ' "$local_log"; then
+        echo "local-file copy reached the FUSE read callback" >&2
+        cat "$local_log" >&2
+        exit 1
+fi
 
 # There is no local archived.txt in the source tree.  A successful read here
 # therefore verifies that force mode does not try to register archive handles
 # as passthrough backing files.
+log_offset=$(( $(wc -c <"$log") + 1 ))
 printf '%s\n' archive-data | cmp - "$mnt/archived.txt" || exit 1
+sleep 1
+tail -c +"$log_offset" "$log" >"$archive_log"
+if ! grep -q 'opcode: READ ' "$archive_log"; then
+        echo "archive read unexpectedly bypassed the FUSE read callback" >&2
+        cat "$archive_log" >&2
+        exit 1
+fi
 
 exit 0

--- a/tests/passthrough.sh
+++ b/tests/passthrough.sh
@@ -28,6 +28,7 @@ archive_src=$tmp/archive-source
 mnt=$tmp/mount
 log=$tmp/rar2fs.log
 local_log=$tmp/local.log
+create_log=$tmp/create.log
 archive_log=$tmp/archive.log
 pid=
 
@@ -82,6 +83,25 @@ fi
 if grep -q 'opcode: READ ' "$local_log"; then
         echo "local-file copy reached the FUSE read callback" >&2
         cat "$local_log" >&2
+        exit 1
+fi
+
+# A newly created local file must return its backing ID as part of the CREATE
+# reply.  Its payload writes must likewise stay out of the rar2fs daemon.
+log_offset=$(( $(wc -c <"$log") + 1 ))
+cp "$src/local.bin" "$mnt/created.bin" || exit 1
+cmp "$src/local.bin" "$src/created.bin" || exit 1
+sleep 1
+tail -c +"$log_offset" "$log" >"$create_log"
+if ! grep -Eq 'passthrough backing id [1-9][0-9]* for .*created\.bin' \
+                "$create_log"; then
+        echo "created file was not registered as a passthrough backing file" >&2
+        cat "$create_log" >&2
+        exit 1
+fi
+if grep -q 'opcode: WRITE ' "$create_log"; then
+        echo "created-file copy reached the FUSE write callback" >&2
+        cat "$create_log" >&2
         exit 1
 fi
 

--- a/tests/passthrough.sh
+++ b/tests/passthrough.sh
@@ -34,6 +34,7 @@ pid=
 
 cleanup()
 {
+        exec 3<&-
         if mountpoint -q "$mnt" 2>/dev/null; then
                 fusermount3 -u "$mnt" >/dev/null 2>&1 || true
         fi
@@ -73,13 +74,25 @@ done
 # Read a local file through cp.  A registered passthrough handle must keep the
 # READ request in the kernel instead of dispatching it to the rar2fs daemon.
 log_offset=$(( $(wc -c <"$log") + 1 ))
+# Keep one handle open while cp opens the same FUSE inode again.  Both opens
+# must share one backing ID; registering a second backing object makes the
+# kernel reject the overlapping open with EIO.
+exec 3<"$mnt/local.bin" || exit 1
 cp "$mnt/local.bin" "$tmp/local-copy.bin" || exit 1
 cmp "$src/local.bin" "$tmp/local-copy.bin" || exit 1
+exec 3<&-
 sleep 1
 tail -c +"$log_offset" "$log" >"$local_log"
 if ! grep -Eq 'passthrough backing id [1-9][0-9]* for .*local\.bin' \
                 "$local_log"; then
         echo "local file was not registered as a passthrough backing file" >&2
+        cat "$local_log" >&2
+        exit 1
+fi
+backing_ids=$(sed -n 's/.*passthrough backing id \([1-9][0-9]*\) for .*local\.bin.*/\1/p' \
+                      "$local_log" | sort -u | wc -l)
+if test "$backing_ids" -ne 1; then
+        echo "overlapping opens did not share one passthrough backing ID" >&2
         cat "$local_log" >&2
         exit 1
 fi


### PR DESCRIPTION
This pull request introduces support for FUSE3 and kernel passthrough mode on Linux, while maintaining compatibility with FUSE2. It adds new configuration options, updates the build system, and refactors code to support both FUSE2 and FUSE3 APIs. The changes also include documentation updates for the new passthrough feature and improvements in code maintainability.

**FUSE3 and Passthrough Support:**

* Added detection and preference for `libfuse3` (>= 3.17.1) on Linux, with a new `--disable-fuse3` configure flag and corresponding build logic. The build system now conditionally uses FUSE3 or FUSE2 and sets appropriate preprocessor macros and compiler flags. (`configure.ac`, `Makefile.am`) [[1]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R205-R235) [[2]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R287-R291) [[3]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R342) [[4]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R358) [[5]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810L337-R375) [[6]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R792-L756) [[7]](diffhunk://#diff-0462e381b2fb3286568215681c8983490a37ac9ae0f0c5ee304df7fa6426d4afL2-R2)
* Introduced kernel passthrough support for local files on Linux with FUSE3, including new logic for registering/unregistering backing files and handling passthrough modes (`off`, `auto`, `force`). (`src/rar2fs.c`) [[1]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R40-R50) [[2]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R139-R141) [[3]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R184-R189) [[4]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R1702-R1768) [[5]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R1654-R1666)
* Added a new mount option `-o passthrough=off|auto|force` and documented its behavior in the man page. (`man/rar2fs.1`)

**API Compatibility and Code Refactoring:**

* Refactored code to support both FUSE2 and FUSE3 APIs, including conditional compilation for function signatures, directory filling macros, and capability management. (`src/rar2fs.c`) [[1]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L3202-R3306) [[2]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L3280-R3391) [[3]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L3451-R3572) [[4]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L3530-R3647) [[5]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L3573-R3700) [[6]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L3615-R3739) [[7]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L4394-R4547) [[8]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R4559-R4571) [[9]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L4618-R4788) [[10]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L4652-R4829)
* Updated initialization logic to handle FUSE3 connection capabilities and passthrough negotiation. (`src/rar2fs.c`) [[1]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2L4394-R4547) [[2]](diffhunk://#diff-d579c423765c216e8ec7e0909095d2d4a7e5b5ab40080a3d527fac412a6c35e2R4559-R4571)

**Build System and Documentation:**

* Added `tests` directory to build system and ensured correct Makefile generation for new and existing directories. (`Makefile.am`, `configure.ac`) [[1]](diffhunk://#diff-0462e381b2fb3286568215681c8983490a37ac9ae0f0c5ee304df7fa6426d4afL2-R2) [[2]](diffhunk://#diff-49473dca262eeab3b4a43002adb08b4db31020d190caaad1594b47f1d5daa810R792-L756)
* Improved man page to describe the new passthrough mount option and its usage. (`man/rar2fs.1`)

These changes enable rar2fs to take advantage of new FUSE3 features, especially passthrough for improved performance on local files, while maintaining backward compatibility and configurability.