### PR TITLE
man: use Automake man_MANS instead of custom install hook

### DIFF
--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,10 +1,1 @@
-EXTRA_DIST = rar2fs.1
-
-install-exec-hook:
-	$(MKDIR_P) $(DESTDIR)$(mandir)/man1 && \
-	rm -f $(DESTDIR)$(mandir)/man1/rar2fs.*
-	cp rar2fs.1 $(DESTDIR)$(mandir)/man1 && \
-	chmod 0644 $(DESTDIR)$(mandir)/man1/rar2fs.1
-
-uninstall-hook:
-	rm -f $(DESTDIR)$(mandir)/man1/rar2fs.*
+man_MANS = rar2fs.1


### PR DESCRIPTION
The custom install-exec-hook/uninstall-hook in man/Makefile.am was introduced to support installing a gzip-compressed man page conditionally. That compression feature was removed in 6e3095c, but a simplified copy/chmod hook was kept instead of restoring Automake's native man page handling.

The custom hook's cp+chmod sequence is fragile under tools like checkinstall that intercept filesystem calls, causing installation failures such as:

  chmod: cannot access '/usr/local/share/man/man1/rar2fs.1': No such file or directory

Switch back to the standard man_MANS declaration so Automake generates the install/uninstall rules and installs the file directly with 'install -m 644'.